### PR TITLE
ci: add Github action to run golint on the main branch

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,24 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.54


### PR DESCRIPTION
To prevent pushing not valid code to the main branch (issue #19), I added the offlical github action [golangci/golangci-lint-action](https://github.com/marketplace/actions/run-golangci-lint).

Please fix the invalid code in this PR as a test.

References:
- https://github.com/marketplace/actions/run-golangci-lint