### PR TITLE
update account traces endpoint params

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -872,6 +872,14 @@ paths:
             default: 100
             example: 100
             minimum: 1
+        - name: before_lt
+          in: query
+          description: "omit this parameter to get last traces"
+          required: false
+          schema:
+            type: integer
+            format: int64
+            example: 25758317000002
       responses:
         '200':
           description: account's traces

--- a/oas_client_gen.go
+++ b/oas_client_gen.go
@@ -4138,6 +4138,23 @@ func (c *Client) sendGetAccountTraces(ctx context.Context, params GetAccountTrac
 			return res, errors.Wrap(err, "encode query")
 		}
 	}
+	{
+		// Encode "before_lt" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "before_lt",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.BeforeLt.Get(); ok {
+				return e.EncodeValue(conv.Int64ToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
 	u.RawQuery = q.Values().Encode()
 
 	stage = "EncodeRequest"

--- a/oas_parameters_gen.go
+++ b/oas_parameters_gen.go
@@ -225,6 +225,8 @@ type GetAccountTracesParams struct {
 	// Account ID.
 	AccountID string
 	Limit     OptInt
+	// Omit this parameter to get last traces.
+	BeforeLt OptInt64
 }
 
 // GetAllAuctionsParams is parameters of getAllAuctions operation.


### PR DESCRIPTION
The `before_lt` param is shown in the api docs for the `/v2/accounts/{acount_id}/traces` endpoint but is not available in the tonapi-go package. This updates the api spec to include this parameter. It was unclear if anything else need be done for this change request so please let me know if I should provide anything additional, thank you.